### PR TITLE
Add TelemetryClient and implement update coturn server list

### DIFF
--- a/kia-cli/src/main/kotlin/com/faforever/ice/KiaApplication.kt
+++ b/kia-cli/src/main/kotlin/com/faforever/ice/KiaApplication.kt
@@ -4,6 +4,7 @@ import com.faforever.ice.gpgnet.GpgnetMessage
 import com.faforever.ice.ice4j.CandidatesMessage
 import com.faforever.ice.icebreaker.ApiClient
 import com.faforever.ice.rpc.RpcService
+import com.faforever.ice.telemetry.TelemetryClient
 import com.faforever.ice.util.SocketFactory
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -112,6 +113,7 @@ class KiaApplication : Callable<Int> {
         iceAdapter = IceAdapter(
             iceOptions = iceOptions,
             apiClient = ApiClient(iceOptions, jacksonObjectMapper()),
+            telemetryClient = TelemetryClient(iceOptions, jacksonObjectMapper()),
             onGameConnectionStateChanged = this::onConnectionStateChanged,
             onGpgNetMessageReceived = this::onGpgNetMessageReceived,
             onIceCandidatesGathered = this::onIceMsg,

--- a/kia-lib/src/main/kotlin/com/faforever/ice/IceAdapter.kt
+++ b/kia-lib/src/main/kotlin/com/faforever/ice/IceAdapter.kt
@@ -13,6 +13,8 @@ import com.faforever.ice.ice4j.CandidatesMessage
 import com.faforever.ice.icebreaker.ApiClient
 import com.faforever.ice.peering.CoturnServer
 import com.faforever.ice.peering.RemotePeerOrchestrator
+import com.faforever.ice.telemetry.TelemetryClient
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.net.InetAddress
 import java.net.URI
@@ -49,7 +51,7 @@ class IceAdapter(
     )
     private val connectivityChecker = ConnectivityChecker()
     private val players: MutableMap<Int, RemotePeerOrchestrator> = ConcurrentHashMap()
-//    private val telemetryClient = TelemetryClient(iceOptions, objectMapper)
+    private val telemetryClient = TelemetryClient(iceOptions, jacksonObjectMapper())
 
     fun start(
         accessToken: String,
@@ -77,6 +79,7 @@ class IceAdapter(
                     },
                 )
 
+                telemetryClient.updateCoturnList(coturnServers)
                 lobbyStateFuture = CompletableFuture<Void>()
                 gpgnetProxy.start()
                 connectivityChecker.start()

--- a/kia-lib/src/main/kotlin/com/faforever/ice/IceAdapter.kt
+++ b/kia-lib/src/main/kotlin/com/faforever/ice/IceAdapter.kt
@@ -14,7 +14,6 @@ import com.faforever.ice.icebreaker.ApiClient
 import com.faforever.ice.peering.CoturnServer
 import com.faforever.ice.peering.RemotePeerOrchestrator
 import com.faforever.ice.telemetry.TelemetryClient
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.net.InetAddress
 import java.net.URI
@@ -26,6 +25,7 @@ private val logger = KotlinLogging.logger {}
 class IceAdapter(
     private val iceOptions: IceOptions,
     private val apiClient: ApiClient,
+    private val telemetryClient: TelemetryClient,
     onGameConnectionStateChanged: (String) -> Unit,
     private val onGpgNetMessageReceived: (GpgnetMessage) -> Unit,
     private val onIceCandidatesGathered: (CandidatesMessage) -> Unit,
@@ -51,7 +51,6 @@ class IceAdapter(
     )
     private val connectivityChecker = ConnectivityChecker()
     private val players: MutableMap<Int, RemotePeerOrchestrator> = ConcurrentHashMap()
-    private val telemetryClient = TelemetryClient(iceOptions, jacksonObjectMapper())
 
     fun start(
         accessToken: String,

--- a/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt
+++ b/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt
@@ -8,8 +8,8 @@ import org.java_websocket.handshake.ServerHandshake
 import java.io.IOException
 import java.net.ConnectException
 import java.net.URI
-import java.util.concurrent.CompletableFuture
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
 
 private val logger = KotlinLogging.logger {}
 
@@ -24,10 +24,10 @@ class TelemetryClient(
     private val websocketClient: WebSocketClient
     private var connectingFuture: CompletableFuture<Void>
 
-    inner class TelemetryWebsocketClient(serverUri: URI): WebSocketClient(serverUri) {
+    inner class TelemetryWebsocketClient(serverUri: URI) : WebSocketClient(serverUri) {
 
         override fun onOpen(handshakedata: ServerHandshake) {
-            logger.info {"Telemetry websocket opened"}
+            logger.info { "Telemetry websocket opened" }
         }
 
         override fun onMessage(message: String) {
@@ -82,18 +82,17 @@ class TelemetryClient(
         }
     }
 
-    fun updateCoturnList(servers: Collection<com.faforever.ice.peering.CoturnServer>)
-    {
+    fun updateCoturnList(servers: Collection<com.faforever.ice.peering.CoturnServer>) {
         val telemetryCoturnServers = servers.map { server ->
             CoturnServer(
                 region = "n/a",
                 host = server.uri.host,
                 port = server.uri.port,
-                averageRTT = 0.0
+                averageRTT = 0.0,
             )
         }
 
-        val connectedHost:String = telemetryCoturnServers.map { it.host }.firstOrNull() ?: ""
+        val connectedHost: String = telemetryCoturnServers.map { it.host }.firstOrNull() ?: ""
         val message = UpdateCoturnList(connectedHost, telemetryCoturnServers, UUID.randomUUID())
         sendMessage(message)
     }

--- a/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt
+++ b/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt
@@ -93,7 +93,7 @@ class TelemetryClient(
             )
         }
 
-        val connectedHost:String = telemetryCoturnServers.stream().map(CoturnServer::host).findFirst().orElse(null)
+        val connectedHost:String = telemetryCoturnServers.map { it.host }.firstOrNull() ?: ""
         val message = UpdateCoturnList(connectedHost, telemetryCoturnServers, UUID.randomUUID())
         sendMessage(message)
     }

--- a/kia-lib/src/test/kotlin/com/faforever/ice/IceAdapterIT.kt
+++ b/kia-lib/src/test/kotlin/com/faforever/ice/IceAdapterIT.kt
@@ -6,6 +6,7 @@ import com.faforever.ice.gpgnet.GpgnetMessage
 import com.faforever.ice.ice4j.CandidatesMessage
 import com.faforever.ice.icebreaker.ApiClient
 import com.faforever.ice.peering.CoturnServer
+import com.faforever.ice.telemetry.TelemetryClient
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -46,6 +47,9 @@ class IceAdapterIT {
 
     @MockK
     private lateinit var apiClientMock2: ApiClient
+
+    @MockK(relaxed = true)
+    private lateinit var telemetryClientMock: TelemetryClient
 
     class CandidatesTestForwarder {
         lateinit var adapter1: IceAdapter
@@ -128,6 +132,7 @@ class IceAdapterIT {
                 telemetryServer = "telemetryServer",
             ),
             apiClient = apiClientMock1,
+            telemetryClient = telemetryClientMock,
             onGameConnectionStateChanged = {},
             onGpgNetMessageReceived = {},
             onIceCandidatesGathered = candidatesTestForwarder::onCandidatesFromA1,
@@ -157,6 +162,7 @@ class IceAdapterIT {
                 telemetryServer = "telemetryServer",
             ),
             apiClient = apiClientMock2,
+            telemetryClient = telemetryClientMock,
             onGameConnectionStateChanged = {},
             onGpgNetMessageReceived = {},
             onIceCandidatesGathered = candidatesTestForwarder::onCandidatesFromA2,

--- a/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
+++ b/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
@@ -7,7 +7,9 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -16,33 +18,39 @@ import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
 class TelemetryClientTest {
+    private lateinit var sut: TelemetryClient
+
     @MockK
     private lateinit var mockIceOptions: IceOptions
+
+    private val messageUuid = UUID.fromString("000e8400-e29b-41d4-a716-446655440000")
 
     @BeforeEach
     fun beforeEach() {
         every { mockIceOptions.telemetryServer } returns "wss://mock-telemetryserver.xyz:"
         every { mockIceOptions.userId } returns 5000
         every { mockIceOptions.gameId } returns 12345
+        mockkStatic(UUID::class)
+        every { UUID.randomUUID() } returns messageUuid
 
         mockkConstructor(TelemetryClient.TelemetryWebsocketClient::class)
         every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().connect() } returns Unit
+        sut = TelemetryClient(mockIceOptions, jacksonObjectMapper())
+    }
+
+    @AfterEach
+    fun afterEach() {
+        unmockkStatic(UUID::class)
     }
 
     @Test
     fun `test update coturn servers`() {
-        val messageUuid = UUID.fromString("000e8400-e29b-41d4-a716-446655440000")
-        mockkStatic(UUID::class)
-        every { UUID.randomUUID() } returns messageUuid
-
-        val telemetryClient = TelemetryClient(mockIceOptions, jacksonObjectMapper())
-
         val coturnServers: List<com.faforever.ice.peering.CoturnServer> = listOf(
             com.faforever.ice.peering.CoturnServer(URI.create("stun://coturn1.faforever.com:3478")),
             com.faforever.ice.peering.CoturnServer(URI.create("stun://fr-turn1.xirsys.com:80")),
         )
 
-        telemetryClient.updateCoturnList(coturnServers)
+        sut.updateCoturnList(coturnServers)
 
         verify {
             val expected = "{\"messageType\":\"UpdateCoturnList\"," +
@@ -57,14 +65,9 @@ class TelemetryClientTest {
 
     @Test
     fun `test update coturn servers empty`() {
-        val messageUuid = UUID.fromString("000e8400-e29b-41d4-a716-446655440000")
-        mockkStatic(UUID::class)
-        every { UUID.randomUUID() } returns messageUuid
-
-        val telemetryClient = TelemetryClient(mockIceOptions, jacksonObjectMapper())
         val coturnServers: List<com.faforever.ice.peering.CoturnServer> = listOf()
 
-        telemetryClient.updateCoturnList(coturnServers)
+        sut.updateCoturnList(coturnServers)
 
         verify {
             val expected = "{\"messageType\":\"UpdateCoturnList\"," +

--- a/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
+++ b/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
@@ -46,7 +46,13 @@ class TelemetryClientTest {
         telemetryClient.updateCoturnList(coturnServers)
 
         verify {
-            val expected = "{\"messageType\":\"UpdateCoturnList\",\"connectedHost\":\"coturn1.faforever.com\",\"knownServers\":[{\"region\":\"n/a\",\"host\":\"coturn1.faforever.com\",\"port\":3478,\"averageRTT\":0.0},{\"region\":\"n/a\",\"host\":\"fr-turn1.xirsys.com\",\"port\":80,\"averageRTT\":0.0}],\"messageId\":\"000e8400-e29b-41d4-a716-446655440000\"}"
+            val expected =
+                "{\"messageType\":\"UpdateCoturnList\"," +
+                "\"connectedHost\":\"coturn1.faforever.com\"," +
+                "\"knownServers\":[" +
+                  "{\"region\":\"n/a\",\"host\":\"coturn1.faforever.com\",\"port\":3478,\"averageRTT\":0.0}," +
+                  "{\"region\":\"n/a\",\"host\":\"fr-turn1.xirsys.com\",\"port\":80,\"averageRTT\":0.0}]," +
+                "\"messageId\":\"000e8400-e29b-41d4-a716-446655440000\"}"
             anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(expected)
         }
     }

--- a/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
+++ b/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
@@ -8,12 +8,11 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import java.net.URI
 import java.util.UUID
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.api.Test
-
 
 @ExtendWith(MockKExtension::class)
 class TelemetryClientTest {
@@ -22,9 +21,9 @@ class TelemetryClientTest {
 
     @BeforeEach
     fun beforeEach() {
-        every {mockIceOptions.telemetryServer } returns "wss://mock-telemetryserver.xyz:"
-        every {mockIceOptions.userId } returns 5000
-        every {mockIceOptions.gameId } returns 12345
+        every { mockIceOptions.telemetryServer } returns "wss://mock-telemetryserver.xyz:"
+        every { mockIceOptions.userId } returns 5000
+        every { mockIceOptions.gameId } returns 12345
 
         mockkConstructor(TelemetryClient.TelemetryWebsocketClient::class)
         every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().connect() } returns Unit
@@ -40,18 +39,17 @@ class TelemetryClientTest {
 
         val coturnServers: List<com.faforever.ice.peering.CoturnServer> = listOf(
             com.faforever.ice.peering.CoturnServer(URI.create("stun://coturn1.faforever.com:3478")),
-            com.faforever.ice.peering.CoturnServer(URI.create("stun://fr-turn1.xirsys.com:80"))
+            com.faforever.ice.peering.CoturnServer(URI.create("stun://fr-turn1.xirsys.com:80")),
         )
 
         telemetryClient.updateCoturnList(coturnServers)
 
         verify {
-            val expected =
-                "{\"messageType\":\"UpdateCoturnList\"," +
+            val expected = "{\"messageType\":\"UpdateCoturnList\"," +
                 "\"connectedHost\":\"coturn1.faforever.com\"," +
                 "\"knownServers\":[" +
-                  "{\"region\":\"n/a\",\"host\":\"coturn1.faforever.com\",\"port\":3478,\"averageRTT\":0.0}," +
-                  "{\"region\":\"n/a\",\"host\":\"fr-turn1.xirsys.com\",\"port\":80,\"averageRTT\":0.0}]," +
+                "{\"region\":\"n/a\",\"host\":\"coturn1.faforever.com\",\"port\":3478,\"averageRTT\":0.0}," +
+                "{\"region\":\"n/a\",\"host\":\"fr-turn1.xirsys.com\",\"port\":80,\"averageRTT\":0.0}]," +
                 "\"messageId\":\"$messageUuid\"}"
             anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(expected)
         }
@@ -69,10 +67,9 @@ class TelemetryClientTest {
         telemetryClient.updateCoturnList(coturnServers)
 
         verify {
-            val expected =
-                "{\"messageType\":\"UpdateCoturnList\"," +
-                  "\"connectedHost\":\"\"," +
-                  "\"knownServers\":[]," +
+            val expected = "{\"messageType\":\"UpdateCoturnList\"," +
+                "\"connectedHost\":\"\"," +
+                "\"knownServers\":[]," +
                 "\"messageId\":\"$messageUuid\"}"
             anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(expected)
         }

--- a/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
+++ b/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
@@ -53,12 +53,17 @@ class TelemetryClientTest {
         sut.updateCoturnList(coturnServers)
 
         verify {
-            val expected = "{\"messageType\":\"UpdateCoturnList\"," +
-                "\"connectedHost\":\"coturn1.faforever.com\"," +
-                "\"knownServers\":[" +
-                "{\"region\":\"n/a\",\"host\":\"coturn1.faforever.com\",\"port\":3478,\"averageRTT\":0.0}," +
-                "{\"region\":\"n/a\",\"host\":\"fr-turn1.xirsys.com\",\"port\":80,\"averageRTT\":0.0}]," +
-                "\"messageId\":\"$messageUuid\"}"
+            val expected =
+                """
+                {
+                "messageType":"UpdateCoturnList",
+                "connectedHost":"coturn1.faforever.com",
+                "knownServers":[
+                {"region":"n/a","host":"coturn1.faforever.com","port":3478,"averageRTT":0.0},
+                {"region":"n/a","host":"fr-turn1.xirsys.com","port":80,"averageRTT":0.0}],
+                "messageId":"$messageUuid"
+                }
+                """.trimIndent().replace("\n", "")
             anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(expected)
         }
     }
@@ -70,10 +75,16 @@ class TelemetryClientTest {
         sut.updateCoturnList(coturnServers)
 
         verify {
-            val expected = "{\"messageType\":\"UpdateCoturnList\"," +
-                "\"connectedHost\":\"\"," +
-                "\"knownServers\":[]," +
-                "\"messageId\":\"$messageUuid\"}"
+            val expected =
+                """
+                    {
+                    "messageType":"UpdateCoturnList",
+                    "connectedHost":"",
+                    "knownServers":[],
+                    "messageId":"$messageUuid"
+                    }
+                """.trimIndent().replace("\n", "")
+
             anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(expected)
         }
     }

--- a/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
+++ b/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
@@ -1,0 +1,54 @@
+package com.faforever.ice.telemetry
+
+import com.faforever.ice.IceOptions
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.verify
+import java.net.URI
+import java.util.UUID
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.Test
+
+
+@ExtendWith(MockKExtension::class)
+class TelemetryClientTest {
+    @MockK
+    private lateinit var mockIceOptions: IceOptions
+
+    @BeforeEach
+    fun beforeEach() {
+        every {mockIceOptions.telemetryServer } returns "wss://mock-telemetryserver.xyz:"
+        every {mockIceOptions.userId } returns 5000
+        every {mockIceOptions.gameId } returns 12345
+    }
+
+    @Test
+    fun `test update coturn servers`() {
+        val messageUuid = UUID.fromString("000e8400-e29b-41d4-a716-446655440000")
+        mockkStatic(UUID::class)
+        every { UUID.randomUUID() } returns messageUuid
+
+        mockkConstructor(TelemetryClient.TelemetryWebsocketClient::class)
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().connect() } returns Unit
+
+        val telemetryClient = TelemetryClient(mockIceOptions, jacksonObjectMapper())
+
+        val coturnServers: List<com.faforever.ice.peering.CoturnServer> = listOf(
+            com.faforever.ice.peering.CoturnServer(URI.create("stun://coturn1.faforever.com:3478")),
+            com.faforever.ice.peering.CoturnServer(URI.create("stun://fr-turn1.xirsys.com:80"))
+        )
+
+        telemetryClient.updateCoturnList(coturnServers)
+
+        verify {
+            val expected = "{\"messageType\":\"UpdateCoturnList\",\"connectedHost\":\"coturn1.faforever.com\",\"knownServers\":[{\"region\":\"n/a\",\"host\":\"coturn1.faforever.com\",\"port\":3478,\"averageRTT\":0.0},{\"region\":\"n/a\",\"host\":\"fr-turn1.xirsys.com\",\"port\":80,\"averageRTT\":0.0}],\"messageId\":\"000e8400-e29b-41d4-a716-446655440000\"}"
+            anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(expected)
+        }
+    }
+
+}


### PR DESCRIPTION
The first in a series of PRs porting over telemetry logic from the java ice adapter. 

This PR adds the Telemetry client (really just enables it, most of the code was already there).  It also implements the bit of telemetry logic that updates the coturn server list.

Tested using the test telemetry server:

<img src="https://github.com/FAForever/kotlin-ice-adapter/assets/6394803/fbb73808-8ff8-4872-b347-52c0bde7dbbd" width="400">