### PR TITLE
Make TelemetryClient use message queue and sending loop

### DIFF
--- a/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt
+++ b/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt
@@ -69,8 +69,8 @@ class TelemetryClient(
         websocketClient = TelemetryWebsocketClient(uri)
 
         sendingLoopThread = Thread(this::sendingLoop)
-        sendingLoopThread.uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _: Thread?, e: Throwable? ->
-            logger.error { "Thread sendingLoop crashed unexpectedly: $e" }
+        sendingLoopThread.uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _: Thread, e: Throwable ->
+            logger.error(e) { "Thread sendingLoop crashed unexpectedly: " }
         }
 
         CompletableFuture.runAsync {

--- a/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt
+++ b/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt
@@ -21,6 +21,7 @@ private val logger = KotlinLogging.logger {}
 class TelemetryClient(
     private val iceOptions: IceOptions,
     private val objectMapper: ObjectMapper,
+    private val connectionRetries: Int = 6,
 ) {
     private val serverBaseUrl = iceOptions.telemetryServer
 
@@ -89,7 +90,7 @@ class TelemetryClient(
                     RetryPolicy.builder<ConnectionResult>()
                         .handleResult(ConnectionResult.FAILURE)
                         .withBackoff(Duration.ofSeconds(2), Duration.ofMinutes(1))
-                        .withMaxRetries(6)
+                        .withMaxRetries(connectionRetries)
                         .build(),
                 )
                     .onFailure {

--- a/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
+++ b/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
@@ -41,7 +41,9 @@ class TelemetryClientTest {
         every { IceAdapter.version } returns "9.9.9-SNAPSHOT"
 
         mockkConstructor(TelemetryClient.TelemetryWebsocketClient::class)
-        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().connect() } returns Unit
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().connectBlocking() } returns true
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(any<String>()) } returns Unit
+
         sut = TelemetryClient(mockIceOptions, jacksonObjectMapper())
     }
 
@@ -52,9 +54,7 @@ class TelemetryClientTest {
 
     @Test
     fun `test init connects and registers as peer`() {
-        verify {
-            anyConstructed<TelemetryClient.TelemetryWebsocketClient>().connect()
-
+        verify(timeout = 1000) {
             val expected =
                 """
                 {
@@ -77,7 +77,7 @@ class TelemetryClientTest {
 
         sut.updateCoturnList(coturnServers)
 
-        verify {
+        verify(timeout = 1000) {
             val expected =
                 """
                 {
@@ -99,7 +99,7 @@ class TelemetryClientTest {
 
         sut.updateCoturnList(coturnServers)
 
-        verify {
+        verify(timeout = 1000) {
             val expected =
                 """
                     {

--- a/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
+++ b/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
@@ -55,6 +55,7 @@ class TelemetryClientTest {
     @Test
     fun `test init connects and registers as peer`() {
         verify(timeout = 1000) {
+            anyConstructed<TelemetryClient.TelemetryWebsocketClient>().connectBlocking()
             val expected =
                 """
                 {

--- a/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
+++ b/kia-lib/src/test/kotlin/com/faforever/ice/telemetry/TelemetryClientTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.net.URI
+import java.time.Duration
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -45,8 +46,6 @@ class TelemetryClientTest {
         every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().connectBlocking() } returns true
         every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(any<String>()) } returns Unit
         every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().isOpen } returns true
-
-        sut = TelemetryClient(mockIceOptions, jacksonObjectMapper())
     }
 
     @AfterEach
@@ -77,6 +76,7 @@ class TelemetryClientTest {
 
     @Test
     fun `test update coturn servers`() {
+        sut = TelemetryClient(mockIceOptions, jacksonObjectMapper())
         val coturnServers: List<com.faforever.ice.peering.CoturnServer> = listOf(
             com.faforever.ice.peering.CoturnServer(URI.create("stun://coturn1.faforever.com:3478")),
             com.faforever.ice.peering.CoturnServer(URI.create("stun://fr-turn1.xirsys.com:80")),
@@ -104,6 +104,7 @@ class TelemetryClientTest {
 
     @Test
     fun `test update coturn servers empty`() {
+        sut = TelemetryClient(mockIceOptions, jacksonObjectMapper())
         val coturnServers: List<com.faforever.ice.peering.CoturnServer> = listOf()
 
         sut.updateCoturnList(coturnServers)
@@ -122,6 +123,75 @@ class TelemetryClientTest {
 
                 anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(expected)
             }
+        }
+    }
+
+    @Test
+    fun `test reconnect after websocket closes`() {
+        // Mock connections succeeding and websocket open.
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().connectBlocking() } returns true
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().reconnectBlocking() } returns true
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().isOpen } returns true
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().isClosed } returns false
+
+        sut = TelemetryClient(mockIceOptions, jacksonObjectMapper())
+
+        // Wait for the initial connection and the first message to be sent.
+        await().untilAsserted {
+            verify {
+                anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(any<String>())
+            }
+        }
+
+        // Mock the connection closing and add a message to the send queue.
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().isOpen } returns false
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().isClosed } returns true
+        sut.updateCoturnList(listOf())
+
+        // There should get a reconnect attempt.
+        await().untilAsserted {
+            verify {
+                anyConstructed<TelemetryClient.TelemetryWebsocketClient>().reconnectBlocking()
+            }
+        }
+
+        // Mock that the reconnect succeeded.
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().isOpen } returns true
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().isClosed } returns false
+
+        // The message in the queue should then be sent.
+        await().untilAsserted {
+            verify {
+                anyConstructed<TelemetryClient.TelemetryWebsocketClient>().send(any<String>())
+            }
+        }
+    }
+
+    @Test
+    fun `test exhausting reconnect attempts`() {
+        // Mock Connections failing and websocket closed.
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().connectBlocking() } returns false
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().reconnectBlocking() } returns false
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().isOpen } returns false
+        every { anyConstructed<TelemetryClient.TelemetryWebsocketClient>().isClosed } returns true
+
+        sut = TelemetryClient(mockIceOptions, jacksonObjectMapper(), connectionRetries = 2)
+
+        // Exhaust the connection retries.
+        await().untilAsserted {
+            verify(exactly = 2) {
+                anyConstructed<TelemetryClient.TelemetryWebsocketClient>().reconnectBlocking()
+            }
+        }
+
+        // Another event happens which would normally add another message to the queue.
+        sut.updateCoturnList(listOf())
+
+        // After waiting a bit the send queue shouldn't have done anything. There should only be the
+        // initial two reconnect attempts.
+        await().atLeast(Duration.ofSeconds(1))
+        verify(exactly = 2) {
+            anyConstructed<TelemetryClient.TelemetryWebsocketClient>().reconnectBlocking()
         }
     }
 }


### PR DESCRIPTION
Refactors how `TelemetryClient` connects and sends messages to use a message queue and a separate sending loop thread that sends messages from the queue. This is almost the same implementation as the java-ice-adapter except I added some connection retry logic (java-ice-adapter will only try to reconnect once).  

### Why
I noticed that the initial register as peer message wasn't getting sent because the connection hadn't been established yet. When I ran in the debugger it was slow enough that it did work which is why I didn't catch this before. This was due to the async future returning immediately since [it was using](https://github.com/FAForever/kotlin-ice-adapter/blob/f3fcf74a87ff6d5ab5f4227c72390ede41d499d8/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt#L68) `connect()` rather than `connectBlocking()`.  I think this could be simply fixed by using `connectBlocking()` but this all got me thinking about reconnecting and what happens if messages are dropped.  There was [a bit](https://github.com/FAForever/kotlin-ice-adapter/blob/f3fcf74a87ff6d5ab5f4227c72390ede41d499d8/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt#L39) that tried to reconnect when the connection dropped. But, this overwrites the `connectingFuture` and so any messages waiting on `connectingFuture` would get dropped (I think) and it wouldn't keep trying to reconnect. I had been hoping to avoid the message queue/sending loop logic in the java implementation but I think it makes sense.

