### PR TITLE
Implement telemetry update game state and gpgnet state

### DIFF
--- a/kia-cli/src/main/kotlin/com/faforever/ice/KiaApplication.kt
+++ b/kia-cli/src/main/kotlin/com/faforever/ice/KiaApplication.kt
@@ -1,6 +1,7 @@
 package com.faforever.ice
 
 import com.faforever.ice.gpgnet.GpgnetMessage
+import com.faforever.ice.gpgnet.GpgnetProxy
 import com.faforever.ice.ice4j.CandidatesMessage
 import com.faforever.ice.icebreaker.ApiClient
 import com.faforever.ice.rpc.RpcService
@@ -77,7 +78,7 @@ class KiaApplication : Callable<Int> {
     private lateinit var iceAdapter: IceAdapter
     private lateinit var rpcService: RpcService
 
-    private fun onConnectionStateChanged(newState: String) = rpcService.onConnectionStateChanged(newState)
+    private fun onConnectionStateChanged(newState: GpgnetProxy.ConnectionState) = rpcService.onConnectionStateChanged(newState)
 
     private fun onGpgNetMessageReceived(message: GpgnetMessage) = rpcService.onGpgNetMessageReceived(message)
 

--- a/kia-cli/src/main/kotlin/com/faforever/ice/rpc/RpcService.kt
+++ b/kia-cli/src/main/kotlin/com/faforever/ice/rpc/RpcService.kt
@@ -2,6 +2,7 @@ package com.faforever.ice.rpc
 
 import com.faforever.ice.IceAdapter
 import com.faforever.ice.gpgnet.GpgnetMessage
+import com.faforever.ice.gpgnet.GpgnetProxy
 import com.faforever.ice.ice4j.CandidatesMessage
 import com.faforever.ice.util.ReusableComponent
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -43,8 +44,15 @@ class RpcService(
         }
     }
 
-    fun onConnectionStateChanged(newState: String) {
-        sendNotification("onConnectionStateChanged", listOf(newState))
+    fun onConnectionStateChanged(newState: GpgnetProxy.ConnectionState) {
+        val newStateString: String? = when (newState) {
+            GpgnetProxy.ConnectionState.LISTENING -> null
+            GpgnetProxy.ConnectionState.CONNECTED -> "Connected"
+            GpgnetProxy.ConnectionState.DISCONNECTED -> "Disconnected"
+        }
+        if (newStateString != null) {
+            sendNotification("onConnectionStateChanged", listOf(newState))
+        }
     }
 
     fun onGpgNetMessageReceived(message: GpgnetMessage) {

--- a/kia-lib/src/main/kotlin/com/faforever/ice/gpgnet/GpgnetProxy.kt
+++ b/kia-lib/src/main/kotlin/com/faforever/ice/gpgnet/GpgnetProxy.kt
@@ -21,7 +21,7 @@ private val logger = KotlinLogging.logger {}
  */
 class GpgnetProxy(
     iceOptions: IceOptions,
-    private val onGameConnectionStateChanged: (String) -> Unit,
+    private val onGameConnectionStateChanged: (ConnectionState) -> Unit,
     private val onMessage: (GpgnetMessage) -> Unit,
     private val onFailure: (Throwable) -> Unit,
 ) : ReusableComponent, Closeable {
@@ -45,7 +45,11 @@ class GpgnetProxy(
     var closing: Boolean = false
         private set
     var state: ConnectionState = ConnectionState.DISCONNECTED
-        private set
+        private set(value) {
+            field = value
+            onGameConnectionStateChanged(value)
+        }
+
     private var socket: ServerSocket? = null
     private var gameReaderThread: Thread? = null
     private var gameWriterThread: Thread? = null
@@ -88,7 +92,6 @@ class GpgnetProxy(
 
             synchronized(objectLock) {
                 state = ConnectionState.CONNECTED
-                onGameConnectionStateChanged("Connected")
             }
 
             gameReaderThread = Thread(
@@ -174,7 +177,6 @@ class GpgnetProxy(
 
             closing = true
             state = ConnectionState.DISCONNECTED
-            onGameConnectionStateChanged("Disconnected")
 
             gameReaderThread?.apply {
                 interrupt()

--- a/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/ProtocolV1.kt
+++ b/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/ProtocolV1.kt
@@ -1,5 +1,7 @@
 package com.faforever.ice.telemetry
 
+import com.faforever.ice.game.GameState
+import com.faforever.ice.gpgnet.GpgnetProxy
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.time.Instant
 import java.util.UUID
@@ -47,15 +49,31 @@ data class UpdateCoturnList(
 
 @JvmRecord
 data class UpdateGameState(
-    val newState: String, // TODO: Use GameState enum
+    val newState: GameState,
     override val messageId: UUID = UUID.randomUUID(),
 ) : OutgoingMessageV1
 
 @JvmRecord
 data class UpdateGpgnetState(
-    val newState: String, // TODO: Use GameState enum
+    val newState: GpgnetState,
     override val messageId: UUID = UUID.randomUUID(),
-) : OutgoingMessageV1
+) : OutgoingMessageV1 {
+    enum class GpgnetState {
+        WAITING_FOR_GAME,
+        GAME_CONNECTED,
+        ;
+        companion object {
+            fun from(state: GpgnetProxy.ConnectionState): GpgnetState {
+                return when (state) {
+                    GpgnetProxy.ConnectionState.LISTENING,
+                    GpgnetProxy.ConnectionState.DISCONNECTED,
+                    -> UpdateGpgnetState.GpgnetState.WAITING_FOR_GAME
+                    GpgnetProxy.ConnectionState.CONNECTED -> UpdateGpgnetState.GpgnetState.GAME_CONNECTED
+                }
+            }
+        }
+    }
+}
 
 @JvmRecord
 data class UpdatePeerConnectivity(

--- a/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt
+++ b/kia-lib/src/main/kotlin/com/faforever/ice/telemetry/TelemetryClient.kt
@@ -2,6 +2,8 @@ package com.faforever.ice.telemetry
 
 import com.faforever.ice.IceAdapter
 import com.faforever.ice.IceOptions
+import com.faforever.ice.game.GameState
+import com.faforever.ice.gpgnet.GpgnetProxy
 import com.fasterxml.jackson.databind.ObjectMapper
 import dev.failsafe.Failsafe
 import dev.failsafe.RetryPolicy
@@ -143,5 +145,13 @@ class TelemetryClient(
         val connectedHost: String = telemetryCoturnServers.map { it.host }.firstOrNull() ?: ""
         val message = UpdateCoturnList(connectedHost, telemetryCoturnServers, UUID.randomUUID())
         sendMessage(message)
+    }
+
+    fun updateGpgnetState(newState: GpgnetProxy.ConnectionState) {
+        messageQueue.put(UpdateGpgnetState(UpdateGpgnetState.GpgnetState.from(newState)))
+    }
+
+    fun updateGameState(newState: GameState) {
+        messageQueue.put(UpdateGameState(newState))
     }
 }


### PR DESCRIPTION
Implements updating telemetry server when game state and gpgnet connection state changes.

## GameState
Corresponding java-ice-adapter [code](https://github.com/FAForever/java-ice-adapter/blob/2fbfe308a3abee77bbb22ab6c65f2405507ec6ac/ice-adapter/src/main/java/com/faforever/iceadapter/debug/TelemetryDebugger.java#L165)

Called when we receive a gpgnet message that changes the game state [here](https://github.com/FAForever/java-ice-adapter/blob/2141766fccd23db89b5f2540af1cc97d501206f2/ice-adapter/src/main/java/com/faforever/iceadapter/gpgnet/GPGNetServer.java#L103)


## Gpgnet connection state
Corresponding java-ice-adapter [code](https://github.com/FAForever/java-ice-adapter/blob/2fbfe308a3abee77bbb22ab6c65f2405507ec6ac/ice-adapter/src/main/java/com/faforever/iceadapter/debug/TelemetryDebugger.java#L160)
`    public void gpgnetConnectedDisconnected() {
        sendMessage(new UpdateGpgnetState(
                UUID.randomUUID(),
                GPGNetServer.isConnected() ? "GAME_CONNECTED" : "WAITING_FOR_GAME"
        ));
    }`

This is called when GPGNetServer establishes a connection and when it disconnects.

# Testing
### After adapter starts but before the game is started

![telemetry startup](https://github.com/FAForever/kotlin-ice-adapter/assets/6394803/7e769b57-5485-482e-b59a-40ad456cb51b)

### Game starts up, gpgnet changes to connected

![telemetry launching](https://github.com/FAForever/kotlin-ice-adapter/assets/6394803/80b121f5-f3cc-45fd-a06a-fbecd0990a4f)


### Lobby is joined

![telemetry lobby](https://github.com/FAForever/kotlin-ice-adapter/assets/6394803/92587a98-71da-4193-99b8-bc783ebb99f8)

